### PR TITLE
build.py minor fixes + refactor

### DIFF
--- a/build.py
+++ b/build.py
@@ -3,46 +3,83 @@
 import argparse
 
 args_parser = argparse.ArgumentParser(
-	prog = "build.py",
-	description = "Odin + Sokol Hot Reload Template build script.",
-	epilog = "Made by Karl Zylinski.")
+    prog="build.py",
+    description="Odin + Sokol Hot Reload Template build script.",
+    epilog="Made by Karl Zylinski.",
+)
 
-args_parser.add_argument("-hot-reload",        action="store_true",   help="Build hot reload game DLL. Also builds executable if game not already running. This is the default.")
-args_parser.add_argument("-release",           action="store_true",   help="Build release game executable. Note: Deletes everything in the 'build/release' directory to make sure you get a clean release.")
-args_parser.add_argument("-update-sokol",      action="store_true",   help="Download latest Sokol bindings and latest Sokol shader compiler. Happens automatically when the 'sokol-shdc' and 'source/sokol' directories are missing. Note: Deletes everything in 'sokol-shdc' and 'source/sokol' directories. Also causes -compile-sokol to happen.")
-args_parser.add_argument("-compile-sokol",     action="store_true",   help="Compile Sokol C libraries for the current platform. Also compile web (WASM) libraries if emscripten is found (optional). Use -emsdk-path to point out emscripten SDK if not in PATH.")
-args_parser.add_argument("-run",               action="store_true",   help="Run the executable after compiling it.")
-args_parser.add_argument("-debug",             action="store_true",   help="Create debuggable binaries. Makes it possible to debug hot reload and release build in a debugger. For the web build it means that better error messages are printed to console. Debug mode comes with a performance penalty.")
-args_parser.add_argument("-no-shader-compile", action="store_true",   help="Don't compile shaders.")
-args_parser.add_argument("-web",               action="store_true",   help="Build web release. Make sure emscripten (emcc) is in your PATH or use -emsdk-path flag to specify where it lives.")
-args_parser.add_argument("-emsdk-path",                               help="Path to where you have emscripten installed. Should be the root directory of your emscripten installation. Not necessary if emscripten is in your PATH. Can be used with both -web and -compile-sokol (the latter needs it when building the Sokol web (WASM) libraries).")
-args_parser.add_argument("-gl",                action="store_true",   help="Force OpenGL Sokol backend. Useful on some older computers, for example old MacBooks that don't support Metal.")
+args_parser.add_argument(
+    "-hot-reload",
+    action="store_true",
+    help="Build hot reload game DLL. Also builds executable if game not already running. This is the default.",
+)
+args_parser.add_argument(
+    "-release",
+    action="store_true",
+    help="Build release game executable. Note: Deletes everything in the 'build/release' directory to make sure you get a clean release.",
+)
+args_parser.add_argument(
+    "-update-sokol",
+    action="store_true",
+    help="Download latest Sokol bindings and latest Sokol shader compiler. Happens automatically when the 'sokol-shdc' and 'source/sokol' directories are missing. Note: Deletes everything in 'sokol-shdc' and 'source/sokol' directories. Also causes -compile-sokol to happen.",
+)
+args_parser.add_argument(
+    "-compile-sokol",
+    action="store_true",
+    help="Compile Sokol C libraries for the current platform. Also compile web (WASM) libraries if emscripten is found (optional). Use -emsdk-path to point out emscripten SDK if not in PATH.",
+)
+args_parser.add_argument(
+    "-run", action="store_true", help="Run the executable after compiling it."
+)
+args_parser.add_argument(
+    "-debug",
+    action="store_true",
+    help="Create debuggable binaries. Makes it possible to debug hot reload and release build in a debugger. For the web build it means that better error messages are printed to console. Debug mode comes with a performance penalty.",
+)
+args_parser.add_argument(
+    "-no-shader-compile", action="store_true", help="Don't compile shaders."
+)
+args_parser.add_argument(
+    "-web",
+    action="store_true",
+    help="Build web release. Make sure emscripten (emcc) is in your PATH or use -emsdk-path flag to specify where it lives.",
+)
+args_parser.add_argument(
+    "-emsdk-path",
+    help="Path to where you have emscripten installed. Should be the root directory of your emscripten installation. Not necessary if emscripten is in your PATH. Can be used with both -web and -compile-sokol (the latter needs it when building the Sokol web (WASM) libraries).",
+)
+args_parser.add_argument(
+    "-gl",
+    action="store_true",
+    help="Force OpenGL Sokol backend. Useful on some older computers, for example old MacBooks that don't support Metal.",
+)
 
-import urllib.request
-import os
-import zipfile
-import shutil
-import platform
-import subprocess
 import functools
-from enum import Enum
+import os
+import platform
+import shutil
+import subprocess
+import urllib.request
+import zipfile
 
 args = args_parser.parse_args()
 
 num_build_modes = 0
 if args.hot_reload:
-	num_build_modes += 1
+    num_build_modes += 1
 if args.release:
-	num_build_modes += 1
+    num_build_modes += 1
 if args.web:
-	num_build_modes += 1
+    num_build_modes += 1
 
 if num_build_modes > 1:
-	print("Can only use one of: -hot-reload, -release and -web.")
-	exit(1)
+    print("Can only use one of: -hot-reload, -release and -web.")
+    exit(1)
 elif num_build_modes == 0 and not args.update_sokol and not args.compile_sokol:
-	print("You must use one of: -hot-reload, -release, -web, -update-sokol or -compile-sokol.")
-	exit(1)
+    print(
+        "You must use one of: -hot-reload, -release, -web, -update-sokol or -compile-sokol."
+    )
+    exit(1)
 
 SYSTEM = platform.system()
 IS_WINDOWS = SYSTEM == "Windows"
@@ -51,451 +88,511 @@ IS_LINUX = SYSTEM == "Linux"
 
 assert IS_WINDOWS or IS_OSX or IS_LINUX, "Unsupported platform."
 
+
 def main():
-	do_update = args.update_sokol
+    do_update = args.update_sokol
 
-	# Looks like a fresh setup, no sokol anywhere! Trigger automatic update.
-	if not os.path.exists(SOKOL_PATH) and not os.path.exists(SOKOL_SHDC_PATH):
-		do_update = True
+    # Looks like a fresh setup, no sokol anywhere! Trigger automatic update.
+    if not os.path.exists(SOKOL_PATH) and not os.path.exists(SOKOL_SHDC_PATH):
+        do_update = True
 
-	if do_update:
-		update_sokol()
+    if do_update:
+        update_sokol()
 
-	do_compile = do_update or args.compile_sokol
+    do_compile = do_update or args.compile_sokol
 
-	if do_compile:
-		compile_sokol()
+    if do_compile:
+        compile_sokol()
 
-	if not args.no_shader_compile:
-		build_shaders()
+    if not args.no_shader_compile:
+        build_shaders()
 
-	exe_path = ""
-	
-	if args.release:
-		exe_path = build_release()
-	elif args.web:
-		exe_path = build_web()
-	elif args.hot_reload:
-		exe_path = build_hot_reload()
-	
-	if exe_path != "" and args.run:
-		print("Starting " + exe_path)
-		subprocess.Popen(exe_path)
+    exe_path = ""
+
+    if args.release:
+        exe_path = build_release()
+    elif args.web:
+        exe_path = build_web()
+    elif args.hot_reload:
+        exe_path = build_hot_reload()
+
+    if exe_path != "" and args.run:
+        print("Starting " + exe_path)
+        subprocess.Popen(exe_path)
+
 
 def build_shaders():
-	print("Building shaders...")
-	shdc = get_shader_compiler()
+    print("Building shaders...")
+    shdc = get_shader_compiler()
 
-	shaders = []
+    shaders = []
 
-	for root, dirs, files in os.walk("source"):
-		for file in files:
-			if file.endswith(".glsl"):
-				shaders.append(os.path.join(root, file))
+    for root, dirs, files in os.walk("source"):
+        for file in files:
+            if file.endswith(".glsl"):
+                shaders.append(os.path.join(root, file))
 
-	for s in shaders:
-		out_dir = os.path.dirname(s)
-		out_filename = os.path.basename(s)
-		out = out_dir + "/gen__" + (out_filename.removesuffix("glsl") + "odin")
+    for s in shaders:
+        out_dir = os.path.dirname(s)
+        out_filename = os.path.basename(s)
+        out = out_dir + "/gen__" + (out_filename.removesuffix("glsl") + "odin")
 
-		langs = ""
+        langs = ""
 
-		if args.web:
-			langs = "glsl300es"
-		elif IS_WINDOWS:
-			langs = "hlsl5"
-		elif IS_LINUX:
-			langs = "glsl430"
-		elif IS_OSX:
-			langs = "glsl410" if args.gl else "metal_macos"
+        if args.web:
+            langs = "glsl300es"
+        elif IS_WINDOWS:
+            langs = "hlsl5"
+        elif IS_LINUX:
+            langs = "glsl430"
+        elif IS_OSX:
+            langs = "glsl410" if args.gl else "metal_macos"
 
-		execute(shdc + " -i %s -o %s -l %s -f sokol_odin" % (s, out, langs))
+        execute(shdc + " -i %s -o %s -l %s -f sokol_odin" % (s, out, langs))
+
 
 def get_shader_compiler():
-	path = ""
+    path = ""
 
-	arch = platform.machine()
+    arch = platform.machine()
 
-	if IS_WINDOWS:
-		path = "sokol-shdc\\win32\\sokol-shdc.exe"
-	elif IS_LINUX:
-		if "arm64" in arch or "aarch64" in arch:
-			path = "sokol-shdc/linux_arm64/sokol-shdc"
-		else:
-			path = "sokol-shdc/linux/sokol-shdc"
-	elif IS_OSX:
-		if "arm64" in arch or "aarch64" in arch:
-			path = "sokol-shdc/osx_arm64/sokol-shdc"
-		else:
-			path = "sokol-shdc/osx/sokol-shdc"
+    if IS_WINDOWS:
+        path = "sokol-shdc\\win32\\sokol-shdc.exe"
+    elif IS_LINUX:
+        if "arm64" in arch or "aarch64" in arch:
+            path = "sokol-shdc/linux_arm64/sokol-shdc"
+        else:
+            path = "sokol-shdc/linux/sokol-shdc"
+    elif IS_OSX:
+        if "arm64" in arch or "aarch64" in arch:
+            path = "sokol-shdc/osx_arm64/sokol-shdc"
+        else:
+            path = "sokol-shdc/osx/sokol-shdc"
 
-	assert os.path.exists(path), "Could not find shader compiler. Try running this script with update-sokol parameter"
-	return path
+    assert os.path.exists(path), (
+        "Could not find shader compiler. Try running this script with update-sokol parameter"
+    )
+    return path
+
 
 path_join = os.path.join
 
 
 def build_hot_reload():
-	out_dir = "build/hot_reload"
+    out_dir = "build/hot_reload"
 
-	if not os.path.exists(out_dir):
-		make_dirs(out_dir)
+    if not os.path.exists(out_dir):
+        make_dirs(out_dir)
 
-	exe = "game_hot_reload" + executable_extension()
-	dll_final_name = out_dir + "/game" + dll_extension()
-	dll = dll_final_name
+    exe = "game_hot_reload" + executable_extension()
+    dll_final_name = out_dir + "/game" + dll_extension()
+    dll = dll_final_name
 
-	if IS_LINUX or IS_OSX:
-		dll = out_dir + "/game_tmp" + dll_extension()
+    if IS_LINUX or IS_OSX:
+        dll = out_dir + "/game_tmp" + dll_extension()
 
-	# Only used on windows
-	pdb_dir = out_dir + "/game_pdbs"
-	pdb_number = 0
-	
-	dll_extra_args = ""
+    # Only used on windows
+    pdb_dir = out_dir + "/game_pdbs"
+    pdb_number = 0
 
-	if args.debug:
-		dll_extra_args += " -debug"
+    dll_extra_args = ""
 
-	if args.gl:
-		dll_extra_args += " -define:SOKOL_USE_GL=true"
+    if args.debug:
+        dll_extra_args += " -debug"
 
-	game_running = process_exists(exe)
+    if args.gl:
+        dll_extra_args += " -define:SOKOL_USE_GL=true"
 
-	if IS_WINDOWS:
-		if not game_running:
-			out_dir_files = os.listdir(out_dir)
+    game_running = process_exists(exe)
 
-			for f in out_dir_files:
-				if f.endswith(".dll"):
-					os.remove(os.path.join(out_dir, f))
+    if IS_WINDOWS:
+        if not game_running:
+            out_dir_files = os.listdir(out_dir)
 
-			if os.path.exists(pdb_dir):
-				shutil.rmtree(pdb_dir)
+            for f in out_dir_files:
+                if f.endswith(".dll"):
+                    os.remove(os.path.join(out_dir, f))
 
-		if not os.path.exists(pdb_dir):
-			make_dirs(pdb_dir)
-		else:
-			pdb_files = os.listdir(pdb_dir)
+            if os.path.exists(pdb_dir):
+                shutil.rmtree(pdb_dir)
 
-			for f in pdb_files:
-				if f.endswith(".pdb"):
-					n = int(f.removesuffix(".pdb").removeprefix("game_"))
+        if not os.path.exists(pdb_dir):
+            make_dirs(pdb_dir)
+        else:
+            pdb_files = os.listdir(pdb_dir)
 
-					if n > pdb_number:
-						pdb_number = n
+            for f in pdb_files:
+                if f.endswith(".pdb"):
+                    n = int(f.removesuffix(".pdb").removeprefix("game_"))
 
-		# On windows we make sure the PDB name for the DLL is unique on each
-		# build. This makes debugging work properly.
-		dll_extra_args += " -pdb-name:%s/game_%i.pdb" % (pdb_dir, pdb_number + 1)
+                    if n > pdb_number:
+                        pdb_number = n
 
-	print("Building " + dll_final_name + "...")
-	execute("odin build source -define:SOKOL_DLL=true -build-mode:dll -out:%s %s" % (dll, dll_extra_args))
+        # On windows we make sure the PDB name for the DLL is unique on each
+        # build. This makes debugging work properly.
+        dll_extra_args += " -pdb-name:%s/game_%i.pdb" % (pdb_dir, pdb_number + 1)
 
-	if IS_LINUX or IS_OSX:
-		os.rename(dll, dll_final_name)
+    print("Building " + dll_final_name + "...")
+    execute(
+        "odin build source -define:SOKOL_DLL=true -build-mode:dll -out:%s %s"
+        % (dll, dll_extra_args)
+    )
 
-	if game_running:
-		print("Hot reloading...")
+    if IS_LINUX or IS_OSX:
+        os.rename(dll, dll_final_name)
 
-		# Hot reloading means the running executable will see the new dll.
-		# So we can just return empty string here. This makes sure that the main
-		# function does not try to run the executable, even if `run` is specified.
-		return ""
+    if game_running:
+        print("Hot reloading...")
 
-	exe_extra_args = ""
+        # Hot reloading means the running executable will see the new dll.
+        # So we can just return empty string here. This makes sure that the main
+        # function does not try to run the executable, even if `run` is specified.
+        return ""
 
-	if IS_WINDOWS:
-		exe_extra_args += " -pdb-name:%s/main_hot_reload.pdb" % out_dir
+    exe_extra_args = ""
 
-	if args.debug:
-		exe_extra_args += " -debug"
+    if IS_WINDOWS:
+        exe_extra_args += " -pdb-name:%s/main_hot_reload.pdb" % out_dir
 
-	if args.gl:
-		exe_extra_args += " -define:SOKOL_USE_GL=true"
+    if args.debug:
+        exe_extra_args += " -debug"
 
-	print("Building " + exe + "...")
-	execute("odin build source/main_hot_reload -strict-style -define:SOKOL_DLL=true -vet -out:%s %s" % (exe, exe_extra_args))
+    if args.gl:
+        exe_extra_args += " -define:SOKOL_USE_GL=true"
 
-	if IS_WINDOWS:
-		dll_name = "sokol_dll_windows_x64_d3d11_debug.dll" if args.debug else "sokol_dll_windows_x64_d3d11_release.dll"
+    print("Building " + exe + "...")
+    execute(
+        "odin build source/main_hot_reload -strict-style -define:SOKOL_DLL=true -vet -out:%s %s"
+        % (exe, exe_extra_args)
+    )
 
-		if not os.path.exists(dll_name):
-			print("Copying %s" % dll_name)
-			shutil.copyfile(SOKOL_PATH + "/" + dll_name, dll_name)
+    if IS_WINDOWS:
+        dll_name = (
+            "sokol_dll_windows_x64_d3d11_debug.dll"
+            if args.debug
+            else "sokol_dll_windows_x64_d3d11_release.dll"
+        )
 
-	if IS_OSX:
-		dylib_folder = "source/sokol/dylib"
+        if not os.path.exists(dll_name):
+            print("Copying %s" % dll_name)
+            shutil.copyfile(SOKOL_PATH + "/" + dll_name, dll_name)
 
-		if not os.path.exists(dylib_folder):
-			print("Dynamic libraries for OSX don't seem to be built. Please re-run 'build.py -compile-sokol'.")
-			exit(1)
+    if IS_OSX:
+        dylib_folder = "source/sokol/dylib"
 
-		if not os.path.exists("dylib"):
-			os.mkdir("dylib")
+        if not os.path.exists(dylib_folder):
+            print(
+                "Dynamic libraries for OSX don't seem to be built. Please re-run 'build.py -compile-sokol'."
+            )
+            exit(1)
 
-		dylibs = os.listdir(dylib_folder)
+        if not os.path.exists("dylib"):
+            os.mkdir("dylib")
 
-		for d in dylibs:
-			src = "%s/%s" % (dylib_folder, d)
-			dest = "dylib/%s" % d
-			do_copy = False
+        dylibs = os.listdir(dylib_folder)
 
-			if not os.path.exists(dest):
-				do_copy = True
-			elif os.path.getsize(dest) != os.path.getsize(src):
-				do_copy = True
+        for d in dylibs:
+            src = "%s/%s" % (dylib_folder, d)
+            dest = "dylib/%s" % d
+            do_copy = False
 
-			if do_copy:
-				print("Copying %s to %s" % (src, dest))
-				shutil.copyfile(src, dest)
+            if not os.path.exists(dest):
+                do_copy = True
+            elif os.path.getsize(dest) != os.path.getsize(src):
+                do_copy = True
 
-	return "./" + exe
+            if do_copy:
+                print("Copying %s to %s" % (src, dest))
+                shutil.copyfile(src, dest)
+
+    return "./" + exe
+
 
 def build_release():
-	out_dir = "build/release"
+    out_dir = "build/release"
 
-	if os.path.exists(out_dir):
-		shutil.rmtree(out_dir)
+    if os.path.exists(out_dir):
+        shutil.rmtree(out_dir)
 
-	make_dirs(out_dir)
+    make_dirs(out_dir)
 
-	exe = out_dir + "/game_release" + executable_extension()
+    exe = out_dir + "/game_release" + executable_extension()
 
-	print("Building " + exe + "...")
+    print("Building " + exe + "...")
 
-	extra_args = ""
+    extra_args = ""
 
-	if not args.debug:
-		extra_args += " -no-bounds-check -o:speed"
+    if not args.debug:
+        extra_args += " -no-bounds-check -o:speed"
 
-		if IS_WINDOWS:
-			extra_args += " -subsystem:windows"
-	else:
-		extra_args += " -debug"
+        if IS_WINDOWS:
+            extra_args += " -subsystem:windows"
+    else:
+        extra_args += " -debug"
 
-	if args.gl:
-		extra_args += " -define:SOKOL_USE_GL=true"
+    if args.gl:
+        extra_args += " -define:SOKOL_USE_GL=true"
 
-	execute("odin build source/main_release -out:%s -strict-style -vet %s" % (exe, extra_args))
-	shutil.copytree("assets", out_dir + "/assets")
+    execute(
+        "odin build source/main_release -out:%s -strict-style -vet %s"
+        % (exe, extra_args)
+    )
+    shutil.copytree("assets", out_dir + "/assets")
 
-	return exe
+    return exe
+
 
 def build_web():
-	out_dir = "build/web"
-	make_dirs(out_dir)
+    out_dir = "build/web"
+    make_dirs(out_dir)
 
-	odin_extra_args = ""
+    odin_extra_args = ""
 
-	if args.debug:
-		odin_extra_args += " -debug"
+    if args.debug:
+        odin_extra_args += " -debug"
 
-	print("Building js_wasm32 game object...")
-	execute("odin build source/main_web -target:js_wasm32 -build-mode:obj -vet -strict-style -out:%s/game %s" % (out_dir, odin_extra_args))
-	odin_path = subprocess.run(["odin", "root"], capture_output=True, text=True).stdout
+    print("Building js_wasm32 game object...")
+    execute(
+        "odin build source/main_web -target:js_wasm32 -build-mode:obj -vet -strict-style -out:%s/game %s"
+        % (out_dir, odin_extra_args)
+    )
+    odin_path = subprocess.run(["odin", "root"], capture_output=True, text=True).stdout
 
-	shutil.copyfile(os.path.join(odin_path, "core/sys/wasm/js/odin.js"), os.path.join(out_dir, "odin.js"))
-	os.environ["EMSDK_QUIET"] = "1"
+    shutil.copyfile(
+        os.path.join(odin_path, "core/sys/wasm/js/odin.js"),
+        os.path.join(out_dir, "odin.js"),
+    )
+    os.environ["EMSDK_QUIET"] = "1"
 
-	wasm_lib_suffix = "debug.a" if args.debug else "release.a"
+    wasm_lib_suffix = "debug.a" if args.debug else "release.a"
 
-	emcc_files = [
-		"%s/game.wasm.o" % out_dir,
-		"source/sokol/app/sokol_app_wasm_gl_" + wasm_lib_suffix,
-		"source/sokol/glue/sokol_glue_wasm_gl_" + wasm_lib_suffix,
-		"source/sokol/gfx/sokol_gfx_wasm_gl_" + wasm_lib_suffix,
-		"source/sokol/shape/sokol_shape_wasm_gl_" + wasm_lib_suffix,
-		"source/sokol/log/sokol_log_wasm_gl_" + wasm_lib_suffix,
-		"source/sokol/gl/sokol_gl_wasm_gl_" + wasm_lib_suffix,
-	]
+    emcc_files = [
+        "%s/game.wasm.o" % out_dir,
+        "source/sokol/app/sokol_app_wasm_gl_" + wasm_lib_suffix,
+        "source/sokol/glue/sokol_glue_wasm_gl_" + wasm_lib_suffix,
+        "source/sokol/gfx/sokol_gfx_wasm_gl_" + wasm_lib_suffix,
+        "source/sokol/shape/sokol_shape_wasm_gl_" + wasm_lib_suffix,
+        "source/sokol/log/sokol_log_wasm_gl_" + wasm_lib_suffix,
+        "source/sokol/gl/sokol_gl_wasm_gl_" + wasm_lib_suffix,
+    ]
 
-	emcc_files_str = " ".join(emcc_files)
+    emcc_files_str = " ".join(emcc_files)
 
-	# Note --preload-file assets, this bakes in the whole assets directory into
-	# the web build.
-	emcc_flags = "--shell-file source/web/index_template.html --preload-file assets -sWASM_BIGINT -sWARN_ON_UNDEFINED_SYMBOLS=0 -sMAX_WEBGL_VERSION=2 -sASSERTIONS"
+    # Note --preload-file assets, this bakes in the whole assets directory into
+    # the web build.
+    emcc_flags = "--shell-file source/web/index_template.html --preload-file assets -sWASM_BIGINT -sWARN_ON_UNDEFINED_SYMBOLS=0 -sMAX_WEBGL_VERSION=2 -sASSERTIONS"
 
-	build_flags = ""
+    build_flags = ""
 
-	# -g is the emcc debug flag, it makes the errors in the browser console better.
-	if args.debug:
-		build_flags += " -g "
+    # -g is the emcc debug flag, it makes the errors in the browser console better.
+    if args.debug:
+        build_flags += " -g "
 
-	emcc_command = "emcc %s -o %s/index.html %s %s" % (build_flags, out_dir, emcc_files_str, emcc_flags)
+    emcc_command = "emcc %s -o %s/index.html %s %s" % (
+        build_flags,
+        out_dir,
+        emcc_files_str,
+        emcc_flags,
+    )
 
-	emsdk_env = get_emscripten_env_command()
+    emsdk_env = get_emscripten_env_command()
 
-	if emsdk_env:
-		if IS_WINDOWS:
-			emcc_command = emsdk_env + " && " + emcc_command
-		else:
-			emcc_command = "bash -c \"" + emsdk_env + " && " + emcc_command + "\""
-	else:
-		if shutil.which("emcc") is None:
-			print("Could not find emcc. Try providing emscripten SDK path using '-emsdk-path PATH' or run the emsdk_env script inside the emscripten folder before running this script.")
-			exit(1)
+    if emsdk_env:
+        if IS_WINDOWS:
+            emcc_command = emsdk_env + " && " + emcc_command
+        else:
+            emcc_command = 'bash -c "' + emsdk_env + " && " + emcc_command + '"'
+    else:
+        if shutil.which("emcc") is None:
+            print(
+                "Could not find emcc. Try providing emscripten SDK path using '-emsdk-path PATH' or run the emsdk_env script inside the emscripten folder before running this script."
+            )
+            exit(1)
 
-	print("Building web application using emscripten to %s..." % out_dir)
-	execute(emcc_command)
+    print("Building web application using emscripten to %s..." % out_dir)
+    execute(emcc_command)
 
-	# Not needed
-	os.remove(os.path.join(out_dir, "game.wasm.o"))
+    # Not needed
+    os.remove(os.path.join(out_dir, "game.wasm.o"))
+
 
 def execute(cmd):
-	res = os.system(cmd)
-	if res != 0:
-		print("Failed running:" + cmd)
-		exit(1)
+    res = os.system(cmd)
+    if res != 0:
+        print("Failed running:" + cmd)
+        exit(1)
+
 
 def dll_extension():
-	if IS_WINDOWS:
-		return ".dll"
+    if IS_WINDOWS:
+        return ".dll"
 
-	if IS_OSX:
-		return ".dylib"
+    if IS_OSX:
+        return ".dylib"
 
-	return ".so"
+    return ".so"
+
 
 def executable_extension():
-	if IS_WINDOWS:
-		return ".exe"
+    if IS_WINDOWS:
+        return ".exe"
 
-	return ".bin"
+    return ".bin"
+
 
 SOKOL_PATH = "source/sokol"
 SOKOL_SHDC_PATH = "sokol-shdc"
 
+
 def update_sokol():
-	def update_sokol_bindings():
-		SOKOL_ZIP_URL = "https://github.com/floooh/sokol-odin/archive/refs/heads/main.zip"
+    def update_sokol_bindings():
+        SOKOL_ZIP_URL = (
+            "https://github.com/floooh/sokol-odin/archive/refs/heads/main.zip"
+        )
 
-		if os.path.exists(SOKOL_PATH):
-			shutil.rmtree(SOKOL_PATH)
+        if os.path.exists(SOKOL_PATH):
+            shutil.rmtree(SOKOL_PATH)
 
-		temp_zip = "sokol-temp.zip"
-		temp_folder = "sokol-temp"
-		print("Downloading Sokol Odin bindings to directory source/sokol...")
-		urllib.request.urlretrieve(SOKOL_ZIP_URL, temp_zip)
+        temp_zip = "sokol-temp.zip"
+        temp_folder = "sokol-temp"
+        print("Downloading Sokol Odin bindings to directory source/sokol...")
+        urllib.request.urlretrieve(SOKOL_ZIP_URL, temp_zip)
 
-		with zipfile.ZipFile(temp_zip) as zip_file:
-			zip_file.extractall(temp_folder)
-			shutil.copytree(temp_folder + "/sokol-odin-main/sokol", SOKOL_PATH)
+        with zipfile.ZipFile(temp_zip) as zip_file:
+            zip_file.extractall(temp_folder)
+            shutil.copytree(temp_folder + "/sokol-odin-main/sokol", SOKOL_PATH)
 
-		os.remove(temp_zip)
-		shutil.rmtree(temp_folder)
+        os.remove(temp_zip)
+        shutil.rmtree(temp_folder)
 
-	def update_sokol_shdc():
-		if os.path.exists(SOKOL_SHDC_PATH):
-			shutil.rmtree(SOKOL_SHDC_PATH)
+    def update_sokol_shdc():
+        if os.path.exists(SOKOL_SHDC_PATH):
+            shutil.rmtree(SOKOL_SHDC_PATH)
 
-		TOOLS_ZIP_URL = "https://github.com/floooh/sokol-tools-bin/archive/refs/heads/master.zip"
-		temp_zip = "sokol-tools-temp.zip"
-		temp_folder = "sokol-tools-temp"
+        TOOLS_ZIP_URL = (
+            "https://github.com/floooh/sokol-tools-bin/archive/refs/heads/master.zip"
+        )
+        temp_zip = "sokol-tools-temp.zip"
+        temp_folder = "sokol-tools-temp"
 
-		print("Downloading Sokol Shader Compiler to directory sokol-shdc...")
-		urllib.request.urlretrieve(TOOLS_ZIP_URL, temp_zip)
+        print("Downloading Sokol Shader Compiler to directory sokol-shdc...")
+        urllib.request.urlretrieve(TOOLS_ZIP_URL, temp_zip)
 
-		with zipfile.ZipFile(temp_zip) as zip_file:
-			zip_file.extractall(temp_folder)
-			shutil.copytree(temp_folder + "/sokol-tools-bin-master/bin", SOKOL_SHDC_PATH)
+        with zipfile.ZipFile(temp_zip) as zip_file:
+            zip_file.extractall(temp_folder)
+            shutil.copytree(
+                temp_folder + "/sokol-tools-bin-master/bin", SOKOL_SHDC_PATH
+            )
 
-		if IS_LINUX:
-			execute("chmod +x sokol-shdc/linux/sokol-shdc")
-			execute("chmod +x sokol-shdc/linux_arm64/sokol-shdc")
+        if IS_LINUX:
+            execute("chmod +x sokol-shdc/linux/sokol-shdc")
+            execute("chmod +x sokol-shdc/linux_arm64/sokol-shdc")
 
-		if IS_OSX:
-			execute("chmod +x sokol-shdc/osx/sokol-shdc")
-			execute("chmod +x sokol-shdc/osx_arm64/sokol-shdc")
+        if IS_OSX:
+            execute("chmod +x sokol-shdc/osx/sokol-shdc")
+            execute("chmod +x sokol-shdc/osx_arm64/sokol-shdc")
 
-		os.remove(temp_zip)
-		shutil.rmtree(temp_folder)
+        os.remove(temp_zip)
+        shutil.rmtree(temp_folder)
 
-	update_sokol_bindings()
-	update_sokol_shdc()
+    update_sokol_bindings()
+    update_sokol_shdc()
+
 
 def compile_sokol():
-	owd = os.getcwd()
-	os.chdir(SOKOL_PATH)
+    owd = os.getcwd()
+    os.chdir(SOKOL_PATH)
 
-	emsdk_env = get_emscripten_env_command()
-	
-	print("Building Sokol C libraries...")
+    emsdk_env = get_emscripten_env_command()
 
-	if IS_WINDOWS:
-		if shutil.which("cl.exe") is not None:
-			execute("build_clibs_windows.cmd")
-		else:
-			print("cl.exe not in PATH. Try re-running build.py with flag -compile-sokol from a Visual Studio command prompt.")
+    print("Building Sokol C libraries...")
 
-		if emsdk_env:
-			execute(emsdk_env + " && build_clibs_wasm.bat")
-		else:
-			if shutil.which("emcc.bat"):
-				execute("build_clibs_wasm.bat")
-			else:
-				print("emcc not in PATH, skipping building of WASM libs. Tip: You can also use -emsdk-path to specify where emscripten lives.")
+    if IS_WINDOWS:
+        if shutil.which("cl.exe") is not None:
+            execute("build_clibs_windows.cmd")
+        else:
+            print(
+                "cl.exe not in PATH. Try re-running build.py with flag -compile-sokol from a Visual Studio command prompt."
+            )
 
-	elif IS_LINUX:
-		execute("bash build_clibs_linux.sh")
+        if emsdk_env:
+            execute(emsdk_env + " && build_clibs_wasm.bat")
+        else:
+            if shutil.which("emcc.bat"):
+                execute("build_clibs_wasm.bat")
+            else:
+                print(
+                    "emcc not in PATH, skipping building of WASM libs. Tip: You can also use -emsdk-path to specify where emscripten lives."
+                )
 
-		build_wasm_prefix = ""
-		if emsdk_env:
-			os.environ["EMSDK_QUIET"] = "1"
-			build_wasm_prefix += emsdk_env + " && "
-		elif shutil.which("emcc") is not None:
-			execute("bash -c \"" + build_wasm_prefix + " bash build_clibs_wasm.sh\"")
-		else:
-			print("emcc not in PATH, skipping building of WASM libs. Tip: You can also use -emsdk-path to specify where emscripten lives.")
-		
-	elif IS_OSX:
-		execute("bash build_clibs_macos.sh")
-		execute("bash build_clibs_macos_dylib.sh")
-		
-		build_wasm_prefix = ""
-		if emsdk_env:
-			os.environ["EMSDK_QUIET"] = "1"
-			build_wasm_prefix += emsdk_env + " && "
-		elif shutil.which("emcc") is not None:
-			execute("bash -c \"" + build_wasm_prefix + " bash build_clibs_wasm.sh\"")
-		else:
-			print("emcc not in PATH, skipping building of WASM libs. Tip: You can also use -emsdk-path to specify where emscripten lives.")
+    elif IS_LINUX:
+        execute("bash build_clibs_linux.sh")
 
-	os.chdir(owd)
+        build_wasm_prefix = ""
+        if emsdk_env:
+            os.environ["EMSDK_QUIET"] = "1"
+            build_wasm_prefix += emsdk_env + " && "
+        elif shutil.which("emcc") is not None:
+            execute('bash -c "' + build_wasm_prefix + ' bash build_clibs_wasm.sh"')
+        else:
+            print(
+                "emcc not in PATH, skipping building of WASM libs. Tip: You can also use -emsdk-path to specify where emscripten lives."
+            )
+
+    elif IS_OSX:
+        execute("bash build_clibs_macos.sh")
+        execute("bash build_clibs_macos_dylib.sh")
+
+        build_wasm_prefix = ""
+        if emsdk_env:
+            os.environ["EMSDK_QUIET"] = "1"
+            build_wasm_prefix += emsdk_env + " && "
+        elif shutil.which("emcc") is not None:
+            execute('bash -c "' + build_wasm_prefix + ' bash build_clibs_wasm.sh"')
+        else:
+            print(
+                "emcc not in PATH, skipping building of WASM libs. Tip: You can also use -emsdk-path to specify where emscripten lives."
+            )
+
+    os.chdir(owd)
 
 
 def get_emscripten_env_command():
-	if args.emsdk_path is None:
-		return None
+    if args.emsdk_path is None:
+        return None
 
-	if IS_WINDOWS:
-		return os.path.join(args.emsdk_path, "emsdk_env.bat")
-	elif IS_LINUX or IS_OSX:
-		return "source " + os.path.join(args.emsdk_path, "emsdk_env.sh")
+    if IS_WINDOWS:
+        return os.path.join(args.emsdk_path, "emsdk_env.bat")
+    elif IS_LINUX or IS_OSX:
+        return "source " + os.path.join(args.emsdk_path, "emsdk_env.sh")
 
-	return None
+    return None
+
 
 def process_exists(process_name):
-	if IS_WINDOWS:
-		call = 'TASKLIST', '/NH', '/FI', 'imagename eq %s' % process_name
-		return process_name in str(subprocess.check_output(call))
-	else:
-		out = subprocess.run(["pgrep", "-f", process_name], capture_output=True, text=True).stdout
-		return out != ""
+    if IS_WINDOWS:
+        call = "TASKLIST", "/NH", "/FI", "imagename eq %s" % process_name
+        return process_name in str(subprocess.check_output(call))
+    else:
+        out = subprocess.run(
+            ["pgrep", "-f", process_name], capture_output=True, text=True
+        ).stdout
+        return out != ""
 
+    return False
 
-	return False
 
 def make_dirs(path):
-	n = os.path.normpath(path)
-	s = n.split(os.sep)
-	p = ""
+    n = os.path.normpath(path)
+    s = n.split(os.sep)
+    p = ""
 
-	for d in s:
-		p = os.path.join(p, d)
+    for d in s:
+        p = os.path.join(p, d)
 
-		if not os.path.exists(p):
-			os.mkdir(p)
+        if not os.path.exists(p):
+            os.mkdir(p)
+
 
 print = functools.partial(print, flush=True)
 

--- a/build.py
+++ b/build.py
@@ -517,13 +517,12 @@ def compile_sokol():
 
         if emsdk_env:
             execute(emsdk_env + " && build_clibs_wasm.bat")
+        elif shutil.which("emcc.bat"):
+            execute("build_clibs_wasm.bat")
         else:
-            if shutil.which("emcc.bat"):
-                execute("build_clibs_wasm.bat")
-            else:
-                print(
-                    "emcc not in PATH, skipping building of WASM libs. Tip: You can also use -emsdk-path to specify where emscripten lives."
-                )
+            print(
+                "emcc not in PATH, skipping building of WASM libs. Tip: You can also use -emsdk-path to specify where emscripten lives."
+            )
 
     elif IS_LINUX:
         execute("bash build_clibs_linux.sh")
@@ -532,8 +531,9 @@ def compile_sokol():
         if emsdk_env:
             os.environ["EMSDK_QUIET"] = "1"
             build_wasm_prefix += emsdk_env + " && "
-        elif shutil.which("emcc") is not None:
             execute('bash -c "' + build_wasm_prefix + ' bash build_clibs_wasm.sh"')
+        elif shutil.which("emcc") is not None:
+            execute("bash build_clibs_wasm.sh")
         else:
             print(
                 "emcc not in PATH, skipping building of WASM libs. Tip: You can also use -emsdk-path to specify where emscripten lives."
@@ -547,8 +547,9 @@ def compile_sokol():
         if emsdk_env:
             os.environ["EMSDK_QUIET"] = "1"
             build_wasm_prefix += emsdk_env + " && "
-        elif shutil.which("emcc") is not None:
             execute('bash -c "' + build_wasm_prefix + ' bash build_clibs_wasm.sh"')
+        elif shutil.which("emcc") is not None:
+            execute("bash build_clibs_wasm.sh")
         else:
             print(
                 "emcc not in PATH, skipping building of WASM libs. Tip: You can also use -emsdk-path to specify where emscripten lives."

--- a/build.py
+++ b/build.py
@@ -2,117 +2,162 @@
 
 import platform
 from enum import StrEnum
+from pathlib import Path
+
+SOKOL_SHDC_PATH = Path("sokol-shdc")
+SOKOL_PATH = Path("source/sokol")
 
 
 class Sys(StrEnum):
-    win = "Windows"
+    win32 = "Windows"
     osx = "Darwin"
     linux = "Linux"
 
     def dll(self):
         match self:
-            case Sys.win:
+            case Sys.win32:
                 return ".dll"
             case Sys.osx:
                 return ".dylib"
             case Sys.linux:
                 return ".so"
 
-    def exec(self):
-        if self is Sys.win:
+    def executable(self):
+        if self is Sys.win32:
             return ".exe"
 
         return ".bin"
 
+    def is_arm64(self):
+        arch = platform.machine()
+        return "arm64" in arch or "aarch64" in arch
 
+    def target_dir(self):
+        if SYSTEM is Sys.win32:
+            return self.name
+        return f"{self.name}{'_arm64' if self.is_arm64() else ''}"
+
+    def shader_compile_cmd(self):
+        match SYSTEM:
+            case Sys.win32:
+                slang = "hlsl5"
+                executable = "sokol-shdc.exe"
+            case Sys.linux:
+                slang = "glsl430"
+                executable = "sokol-shdc"
+            case Sys.osx:
+                slang = "glsl410" if args.gl else "metal_macos"
+                executable = "sokol-shdc"
+
+        if args.web:
+            slang = "glsl300es"
+
+        path = SOKOL_SHDC_PATH / self.target_dir() / executable
+        assert path.exists(), (
+            "Could not find shader compiler. Try running this script with update-sokol parameter"
+        )
+        return [str(path), "-f", "sokol_odin", "-l", slang]
+
+
+sys = platform.system()
 try:
-    SYSTEM = Sys[platform.system()]
+    SYSTEM = Sys(sys)
 except KeyError as e:
-    msg = "Unsupported platform."
+    msg = f"Unsupported platform '{sys}'"
     raise Exception(msg) from e
 
 import argparse
+import functools
 
 args_parser = argparse.ArgumentParser(
     prog="build.py",
     description="Odin + Sokol Hot Reload Template build script.",
     epilog="Made by Karl Zylinski.",
 )
+bool_flag = functools.partial(args_parser.add_argument, action="store_true")
 
-args_parser.add_argument(
+
+bool_flag(
     "-hot-reload",
-    action="store_true",
-    help="Build hot reload game DLL. Also builds executable if game not already running. This is the default.",
+    help=(
+        "Build hot reload game DLL."
+        "Also builds executable if game not already running."
+        "This is the default."
+    ),
 )
-args_parser.add_argument(
+bool_flag(
     "-release",
-    action="store_true",
-    help="Build release game executable. Note: Deletes everything in the 'build/release' directory to make sure you get a clean release.",
+    help=(
+        "Build release game executable."
+        "Note: Deletes everything in the 'build/release' directory to make sure you get a clean release."
+    ),
 )
-args_parser.add_argument(
+bool_flag(
     "-update-sokol",
-    action="store_true",
-    help="Download latest Sokol bindings and latest Sokol shader compiler. Happens automatically when the 'sokol-shdc' and 'source/sokol' directories are missing. Note: Deletes everything in 'sokol-shdc' and 'source/sokol' directories. Also causes -compile-sokol to happen.",
+    help=(
+        "Download latest Sokol bindings and latest Sokol shader compiler."
+        f"Happens automatically when the '{SOKOL_SHDC_PATH}' and '{SOKOL_PATH}' directories are missing."
+        f"Note: Deletes everything in '{SOKOL_SHDC_PATH}' and '{SOKOL_PATH}' directories."
+        "Also causes -compile-sokol to happen."
+    ),
 )
-args_parser.add_argument(
+bool_flag(
     "-compile-sokol",
-    action="store_true",
-    help="Compile Sokol C libraries for the current platform. Also compile web (WASM) libraries if emscripten is found (optional). Use -emsdk-path to point out emscripten SDK if not in PATH.",
+    help=(
+        "Compile Sokol C libraries for the current platform."
+        "Also compile web (WASM) libraries if emscripten is found (optional)."
+        "Use -emsdk-path to point out emscripten SDK if not in PATH."
+    ),
 )
-args_parser.add_argument(
-    "-run", action="store_true", help="Run the executable after compiling it."
-)
-args_parser.add_argument(
+bool_flag("-run", help="Run the executable after compiling it.")
+bool_flag(
     "-debug",
-    action="store_true",
-    help="Create debuggable binaries. Makes it possible to debug hot reload and release build in a debugger. For the web build it means that better error messages are printed to console. Debug mode comes with a performance penalty.",
+    help=(
+        "Create debuggable binaries."
+        "Makes it possible to debug hot reload and release build in a debugger."
+        "For the web build it means that better error messages are printed to console."
+        "Debug mode comes with a performance penalty."
+    ),
 )
-args_parser.add_argument(
-    "-no-shader-compile", action="store_true", help="Don't compile shaders."
-)
-args_parser.add_argument(
+bool_flag("-no-shader-compile", help="Don't compile shaders.")
+bool_flag(
     "-web",
-    action="store_true",
     help="Build web release. Make sure emscripten (emcc) is in your PATH or use -emsdk-path flag to specify where it lives.",
 )
 args_parser.add_argument(
     "-emsdk-path",
-    help="Path to where you have emscripten installed. Should be the root directory of your emscripten installation. Not necessary if emscripten is in your PATH. Can be used with both -web and -compile-sokol (the latter needs it when building the Sokol web (WASM) libraries).",
+    help=(
+        "Path to where you have emscripten installed."
+        "Should be the root directory of your emscripten installation."
+        "Not necessary if emscripten is in your PATH."
+        "Can be used with both -web and -compile-sokol (the latter needs it when building the Sokol web (WASM) libraries)."
+    ),
 )
-args_parser.add_argument(
+bool_flag(
     "-gl",
-    action="store_true",
-    help="Force OpenGL Sokol backend. Useful on some older computers, for example old MacBooks that don't support Metal.",
+    help=(
+        "Force OpenGL Sokol backend."
+        "Useful on some older computers, for example old MacBooks that don't support Metal."
+    ),
 )
 
 args = args_parser.parse_args()
 
-num_build_modes = sum(map(int, [args.hot_reload, args.release, args.web]))
-
-if num_build_modes > 1:
+if sum([args.hot_reload, args.release, args.web]) > 1:
     print("Can only use one of: -hot-reload, -release and -web.")
     exit(1)
-elif not (num_build_modes or args.update_sokol or args.compile_sokol):
-    print(
-        "You must use one of: -hot-reload, -release, -web, -update-sokol or -compile-sokol."
-    )
-    exit(1)
 
-import functools
-import os
 import shutil
 import subprocess
 import urllib.request
 import zipfile
-
-SOKOL_PATH = "source/sokol"
-SOKOL_SHDC_PATH = "sokol-shdc"
+from os import chdir, chmod, environ
 
 
 def main():
     if args.update_sokol or not (
         # Looks like a fresh setup, no sokol anywhere! Trigger automatic update.
-        os.path.exists(SOKOL_PATH) or os.path.exists(SOKOL_SHDC_PATH)
+        SOKOL_PATH.exists() or SOKOL_SHDC_PATH.exists()
     ):
         update_sokol()
         compile_sokol()
@@ -137,116 +182,78 @@ def main():
 
 def build_shaders():
     print("Building shaders...")
-    shdc = get_shader_compiler()
+    shdc = SYSTEM.shader_compile_cmd()
 
-    if args.web:
-        langs = "glsl300es"
-    else:
-        match SYSTEM:
-            case Sys.win:
-                langs = "hlsl5"
-            case Sys.linux:
-                langs = "glsl430"
-            case Sys.osx:
-                langs = "glsl410" if args.gl else "metal_macos"
+    for s in [f for f in Path("source").iterdir() if f.suffix == ".glsl"]:
+        out = (s.parent / f"gen__{s.name}").with_suffix(".odin")
 
-    for s in [
-        os.path.join(root, file)
-        for root, dirs, files in os.walk("source")
-        for file in files
-        if file.endswith(".glsl")
-    ]:
-        out_dir = os.path.dirname(s)
-        out_filename = os.path.basename(s)
-        out = out_dir + "/gen__" + (out_filename.removesuffix("glsl") + "odin")
-
-        execute(shdc + " -i %s -o %s -l %s -f sokol_odin" % (s, out, langs))
-
-
-def get_shader_compiler():
-    arch = platform.machine()
-
-    match SYSTEM:
-        case Sys.win:
-            path = "sokol-shdc\\win32\\sokol-shdc.exe"
-        case Sys.linux:
-            if "arm64" in arch or "aarch64" in arch:
-                path = "sokol-shdc/linux_arm64/sokol-shdc"
-            else:
-                path = "sokol-shdc/linux/sokol-shdc"
-        case Sys.osx:
-            if "arm64" in arch or "aarch64" in arch:
-                path = "sokol-shdc/osx_arm64/sokol-shdc"
-            else:
-                path = "sokol-shdc/osx/sokol-shdc"
-
-    assert os.path.exists(path), (
-        "Could not find shader compiler. Try running this script with update-sokol parameter"
-    )
-    return path
+        execute(shdc + ["-i", str(s), "-o", str(out)])
 
 
 def build_hot_reload():
-    out_dir = "build/hot_reload"
+    out_dir = Path("build/hot_reload")
+    out_dir.mkdir(parents=True, exist_ok=True)
 
-    if not os.path.exists(out_dir):
-        make_dirs(out_dir)
+    exe = "game_hot_reload" + SYSTEM.executable()
+    dll_final_name = (out_dir / "game").with_suffix(SYSTEM.dll())
 
-    exe = "game_hot_reload" + SYSTEM.exec()
-    dll_final_name = out_dir + "/game" + SYSTEM.dll()
-    dll = dll_final_name
-
-    if SYSTEM is not Sys.win:
-        dll = out_dir + "/game_tmp" + SYSTEM.dll()
-
-    dll_extra_args = ""
-
-    if args.debug:
-        dll_extra_args += " -debug"
-
-    if args.gl:
-        dll_extra_args += " -define:SOKOL_USE_GL=true"
+    if SYSTEM is not Sys.win32:
+        dll = (out_dir / "game_tmp").with_suffix(SYSTEM.dll())
+    else:
+        dll = dll_final_name
 
     game_running = process_exists(exe)
 
-    if SYSTEM is Sys.win:
-        pdb_dir = out_dir + "/game_pdbs"
+    if SYSTEM is Sys.win32:
+        pdb_dir = out_dir / "game_pdbs"
         pdb_number = 0
 
         if not game_running:
-            out_dir_files = os.listdir(out_dir)
+            for f in out_dir.iterdir():
+                if f.suffix == ".dll":
+                    f.unlink()
 
-            for f in out_dir_files:
-                if f.endswith(".dll"):
-                    os.remove(os.path.join(out_dir, f))
-
-            if os.path.exists(pdb_dir):
+            if pdb_dir.exists():
                 shutil.rmtree(pdb_dir)
 
-        if not os.path.exists(pdb_dir):
-            make_dirs(pdb_dir)
+        if not pdb_dir.exists():
+            pdb_dir.mkdir(parents=True)
         else:
-            pdb_files = os.listdir(pdb_dir)
-
-            for f in pdb_files:
-                if f.endswith(".pdb"):
-                    n = int(f.removesuffix(".pdb").removeprefix("game_"))
-
-                    if n > pdb_number:
-                        pdb_number = n
+            prefix = len("game_")
+            if pdbs := [
+                int(f.stem[prefix:]) for f in pdb_dir.iterdir() if f.suffix == ".pdb"
+            ]:
+                pdb_number = max(pdbs)
+            else:
+                pdb_number = 0
 
         # On windows we make sure the PDB name for the DLL is unique on each
         # build. This makes debugging work properly.
-        dll_extra_args += " -pdb-name:%s/game_%i.pdb" % (pdb_dir, pdb_number + 1)
+        dll_extra_args = [f"-pdb-name:{pdb_dir / f'game_{pdb_number + 1}'}.pdb"]
+    else:
+        dll_extra_args = []
 
-    print("Building " + dll_final_name + "...")
+    if args.debug:
+        dll_extra_args.append("-debug")
+
+    if args.gl:
+        dll_extra_args.append("-define:SOKOL_USE_GL=true")
+
+    print(f"Building {dll_final_name}...")
     execute(
-        "odin build source -define:SOKOL_DLL=true -build-mode:dll -out:%s %s"
-        % (dll, dll_extra_args)
+        [
+            "odin",
+            "build",
+            "source",
+            "-define:SOKOL_DLL=true",
+            "-build-mode:dll",
+            f"-out:{dll}",
+        ]
+        + dll_extra_args
     )
 
-    if SYSTEM is not Sys.win:
-        os.rename(dll, dll_final_name)
+    if SYSTEM is not Sys.win32:
+        dll.rename(dll_final_name)
 
     if game_running:
         print("Hot reloading...")
@@ -256,59 +263,56 @@ def build_hot_reload():
         # function does not try to run the executable, even if `run` is specified.
         return ""
 
-    exe_extra_args = ""
-
-    if SYSTEM is Sys.win:
-        exe_extra_args += " -pdb-name:%s/main_hot_reload.pdb" % out_dir
+    if SYSTEM is Sys.win32:
+        exe_extra_args = [f"-pdb-name:{out_dir / 'main_hot_reload.pdb'}"]
+    else:
+        exe_extra_args = []
 
     if args.debug:
-        exe_extra_args += " -debug"
+        exe_extra_args.append("-debug")
 
     if args.gl:
-        exe_extra_args += " -define:SOKOL_USE_GL=true"
+        exe_extra_args.append("-define:SOKOL_USE_GL=true")
 
-    print("Building " + exe + "...")
+    print(f"Building {exe}...")
     execute(
-        "odin build source/main_hot_reload -strict-style -define:SOKOL_DLL=true -vet -out:%s %s"
-        % (exe, exe_extra_args)
+        [
+            "odin",
+            "build",
+            "source/main_hot_reload",
+            "-strict-style",
+            "-define:SOKOL_DLL=true",
+            "-vet",
+            f"-out:{exe}",
+        ]
+        + exe_extra_args
     )
 
-    if SYSTEM is Sys.win:
-        dll_name = (
-            "sokol_dll_windows_x64_d3d11_debug.dll"
-            if args.debug
-            else "sokol_dll_windows_x64_d3d11_release.dll"
+    if SYSTEM is Sys.win32:
+        dll_name = Path(
+            f"sokol_dll_windows_x64_d3d11_{'debug' if args.debug else 'release'}.dll"
         )
 
-        if not os.path.exists(dll_name):
+        if not dll_name.exists():
             print("Copying %s" % dll_name)
-            shutil.copyfile(SOKOL_PATH + "/" + dll_name, dll_name)
+            shutil.copyfile(SOKOL_PATH / dll_name, dll_name)
 
     if SYSTEM is Sys.osx:
-        dylib_folder = "source/sokol/dylib"
+        dylib_folder = SOKOL_PATH / "dylib"
 
-        if not os.path.exists(dylib_folder):
+        if not dylib_folder.exists():
             print(
                 "Dynamic libraries for OSX don't seem to be built. Please re-run 'build.py -compile-sokol'."
             )
             exit(1)
 
-        if not os.path.exists("dylib"):
-            os.mkdir("dylib")
+        out_dir = Path("dylib")
+        out_dir.mkdir(exist_ok=True)
 
-        dylibs = os.listdir(dylib_folder)
+        for src in [f for f in dylib_folder.iterdir() if not f.is_dir()]:
+            dest = out_dir / src.name
 
-        for d in dylibs:
-            src = "%s/%s" % (dylib_folder, d)
-            dest = "dylib/%s" % d
-            do_copy = False
-
-            if not os.path.exists(dest):
-                do_copy = True
-            elif os.path.getsize(dest) != os.path.getsize(src):
-                do_copy = True
-
-            if do_copy:
+            if not dest.exists() or dest.stat().st_size != src.stat().st_size:
                 print("Copying %s to %s" % (src, dest))
                 shutil.copyfile(src, dest)
 
@@ -316,118 +320,130 @@ def build_hot_reload():
 
 
 def build_release():
-    out_dir = "build/release"
+    out_dir = Path("build/release")
 
-    if os.path.exists(out_dir):
+    if out_dir.exists():
         shutil.rmtree(out_dir)
 
-    make_dirs(out_dir)
+    out_dir.mkdir(parents=True)
 
-    exe = out_dir + "/game_release" + SYSTEM.exec()
+    exe = (out_dir / "game_release").with_suffix(SYSTEM.executable())
 
-    print("Building " + exe + "...")
-
-    extra_args = ""
+    print(f"Building {exe}...")
 
     if not args.debug:
-        extra_args += " -no-bounds-check -o:speed"
+        extra_args = ["-no-bounds-check", "-o:speed"]
 
-        if SYSTEM is Sys.win:
-            extra_args += " -subsystem:windows"
+        if SYSTEM is Sys.win32:
+            extra_args.append("-subsystem:windows")
     else:
-        extra_args += " -debug"
+        extra_args = ["-debug"]
 
     if args.gl:
-        extra_args += " -define:SOKOL_USE_GL=true"
+        extra_args.append("-define:SOKOL_USE_GL=true")
 
     execute(
-        "odin build source/main_release -out:%s -strict-style -vet %s"
-        % (exe, extra_args)
+        ["odin", "build", "source/main_release", f"-out:{exe}", "-strict-style", "-vet"]
+        + extra_args
     )
-    shutil.copytree("assets", out_dir + "/assets")
+    shutil.copytree("assets", out_dir / "assets")
 
-    return exe
+    return str(exe)
 
 
 def build_web():
-    out_dir = "build/web"
-    make_dirs(out_dir)
+    if emsdk_env := emscripten_env():
+        emcc_prefix = emsdk_env + ["&&"]
+    else:
+        emcc_prefix = []
 
-    odin_extra_args = ""
+    if shutil.which("emcc") is None:
+        print(
+            "Could not find emcc. Try providing emscripten SDK path using '-emsdk-path PATH' or run the emsdk_env script inside the emscripten folder before running this script."
+        )
+        exit(1)
+
+    out_dir = Path("build/web")
+    out_dir.mkdir(parents=True, exist_ok=True)
 
     if args.debug:
-        odin_extra_args += " -debug"
+        odin_extra_args = ["-debug"]
+    else:
+        odin_extra_args = []
 
     print("Building js_wasm32 game object...")
     execute(
-        "odin build source/main_web -target:js_wasm32 -build-mode:obj -vet -strict-style -out:%s/game %s"
-        % (out_dir, odin_extra_args)
+        [
+            "odin",
+            "build",
+            "source/main_web",
+            "-target:js_wasm32",
+            "-build-mode:obj",
+            "-vet",
+            "-strict-style",
+            f"-out:{out_dir / 'game'}",
+            "%s",
+        ]
+        + odin_extra_args
     )
-    odin_path = subprocess.run(["odin", "root"], capture_output=True, text=True).stdout
+    odin_path = Path(
+        execute(["odin", "root"], shell=True, capture_output=True, text=True)
+    )
 
     shutil.copyfile(
-        os.path.join(odin_path, "core/sys/wasm/js/odin.js"),
-        os.path.join(out_dir, "odin.js"),
+        odin_path / "core/sys/wasm/js/odin.js",
+        out_dir / "odin.js",
     )
-    os.environ["EMSDK_QUIET"] = "1"
-
-    wasm_lib_suffix = "debug.a" if args.debug else "release.a"
-
-    emcc_files = [
-        "%s/game.wasm.o" % out_dir,
-        "source/sokol/app/sokol_app_wasm_gl_" + wasm_lib_suffix,
-        "source/sokol/glue/sokol_glue_wasm_gl_" + wasm_lib_suffix,
-        "source/sokol/gfx/sokol_gfx_wasm_gl_" + wasm_lib_suffix,
-        "source/sokol/shape/sokol_shape_wasm_gl_" + wasm_lib_suffix,
-        "source/sokol/log/sokol_log_wasm_gl_" + wasm_lib_suffix,
-        "source/sokol/gl/sokol_gl_wasm_gl_" + wasm_lib_suffix,
-    ]
-
-    emcc_files_str = " ".join(emcc_files)
-
-    # Note --preload-file assets, this bakes in the whole assets directory into
-    # the web build.
-    emcc_flags = "--shell-file source/web/index_template.html --preload-file assets -sWASM_BIGINT -sWARN_ON_UNDEFINED_SYMBOLS=0 -sMAX_WEBGL_VERSION=2 -sASSERTIONS"
-
-    build_flags = ""
 
     # -g is the emcc debug flag, it makes the errors in the browser console better.
     if args.debug:
-        build_flags += " -g "
+        build_flags = ["-g"]
+    else:
+        build_flags = []
 
-    emcc_command = "emcc %s -o %s/index.html %s %s" % (
-        build_flags,
-        out_dir,
-        emcc_files_str,
-        emcc_flags,
+    print(f"Building web application using emscripten to {out_dir}...")
+
+    # Note --preload-file assets, this bakes in the whole assets directory into the web build.
+    wasm_lib_suffix = "debug.a" if args.debug else "release.a"
+    execute(
+        emcc_prefix
+        + ["emcc"]
+        + build_flags
+        + ["-o", str(out_dir / "index.html")]
+        + [str(out_dir / "game.wasm.o")]
+        + [
+            str(SOKOL_PATH / (f + wasm_lib_suffix))
+            for f in (
+                "glue/sokol_glue_wasm_gl_"
+                "gfx/sokol_gfx_wasm_gl_"
+                "shape/sokol_shape_wasm_gl_"
+                "log/sokol_log_wasm_gl_"
+                "gl/sokol_gl_wasm_gl_"
+            )
+        ]
+        + [
+            "--shell-file",
+            "source/web/index_template.html",
+            "--preload-file",
+            "assets",
+            "-sWASM_BIGINT",
+            "-sWARN_ON_UNDEFINED_SYMBOLS=0",
+            "-sMAX_WEBGL_VERSION=2",
+            "-sASSERTIONS",
+        ]
     )
 
-    emsdk_env = get_emscripten_env_command()
-
-    if emsdk_env:
-        if SYSTEM is Sys.win:
-            emcc_command = emsdk_env + " && " + emcc_command
-        else:
-            emcc_command = 'bash -c "' + emsdk_env + " && " + emcc_command + '"'
-    else:
-        if shutil.which("emcc") is None:
-            print(
-                "Could not find emcc. Try providing emscripten SDK path using '-emsdk-path PATH' or run the emsdk_env script inside the emscripten folder before running this script."
-            )
-            exit(1)
-
-    print("Building web application using emscripten to %s..." % out_dir)
-    execute(emcc_command)
-
     # Not needed
-    os.remove(os.path.join(out_dir, "game.wasm.o"))
+    (out_dir / "game.wasm.o").unlink()
 
 
-def execute(cmd):
-    res = os.system(cmd)
-    if res != 0:
-        print("Failed running:" + cmd)
+def execute(args: list[str], **kwargs):
+    print("Running", args)
+    res = subprocess.run(args, **kwargs)
+    if res.returncode != 0:
+        print("Failed running:", args, res.stdout, res.stderr)
         exit(1)
+    return res.stdout
 
 
 def update_sokol():
@@ -436,46 +452,42 @@ def update_sokol():
             "https://github.com/floooh/sokol-odin/archive/refs/heads/main.zip"
         )
 
-        if os.path.exists(SOKOL_PATH):
+        if SOKOL_PATH.exists():
             shutil.rmtree(SOKOL_PATH)
 
-        temp_zip = "sokol-temp.zip"
-        temp_folder = "sokol-temp"
-        print("Downloading Sokol Odin bindings to directory source/sokol...")
+        temp_zip = Path("sokol-temp.zip")
+        temp_folder = Path("sokol-temp")
+        print(f"Downloading Sokol Odin bindings to directory {SOKOL_PATH}...")
         urllib.request.urlretrieve(SOKOL_ZIP_URL, temp_zip)
 
         with zipfile.ZipFile(temp_zip) as zip_file:
             zip_file.extractall(temp_folder)
-            shutil.copytree(temp_folder + "/sokol-odin-main/sokol", SOKOL_PATH)
+            shutil.copytree(temp_folder / "sokol-odin-main/sokol", SOKOL_PATH)
 
-        os.remove(temp_zip)
+        temp_zip.unlink()
         shutil.rmtree(temp_folder)
 
     def update_sokol_shdc():
-        if os.path.exists(SOKOL_SHDC_PATH):
+        if SOKOL_SHDC_PATH.exists():
             shutil.rmtree(SOKOL_SHDC_PATH)
 
         TOOLS_ZIP_URL = (
             "https://github.com/floooh/sokol-tools-bin/archive/refs/heads/master.zip"
         )
-        temp_zip = "sokol-tools-temp.zip"
-        temp_folder = "sokol-tools-temp"
+        temp_zip = Path("sokol-tools-temp.zip")
+        temp_folder = Path("sokol-tools-temp")
 
         print("Downloading Sokol Shader Compiler to directory sokol-shdc...")
         urllib.request.urlretrieve(TOOLS_ZIP_URL, temp_zip)
 
         with zipfile.ZipFile(temp_zip) as zip_file:
             zip_file.extractall(temp_folder)
-            shutil.copytree(
-                temp_folder + "/sokol-tools-bin-master/bin", SOKOL_SHDC_PATH
-            )
+            shutil.copytree(temp_folder / "sokol-tools-bin-master/bin", SOKOL_SHDC_PATH)
 
-        if SYSTEM is not Sys.win:
-            lsys = SYSTEM.value.lower()
-            execute(f"chmod +x sokol-shdc/{lsys}/sokol-shdc")
-            execute(f"chmod +x sokol-shdc/{lsys}_arm64/sokol-shdc")
+        if SYSTEM is not Sys.win32:
+            chmod(SOKOL_SHDC_PATH / SYSTEM.target_dir() / "sokol-shdc", 755)
 
-        os.remove(temp_zip)
+        temp_zip.unlink()
         shutil.rmtree(temp_folder)
 
     update_sokol_bindings()
@@ -483,93 +495,71 @@ def update_sokol():
 
 
 def compile_sokol():
-    owd = os.getcwd()
-    os.chdir(SOKOL_PATH)
+    owd = Path.cwd()
+    chdir(SOKOL_PATH)
 
-    emsdk_env = get_emscripten_env_command()
+    emsdk_env = emscripten_env()
 
     print("Building Sokol C libraries...")
 
     match SYSTEM:
-        case Sys.win:
+        case Sys.win32:
             if shutil.which("cl.exe") is not None:
-                execute("build_clibs_windows.cmd")
+                execute(["build_clibs_windows.cmd"], shell=True)
             else:
                 print(
                     "cl.exe not in PATH. Try re-running build.py with flag -compile-sokol from a Visual Studio command prompt."
                 )
-
-            if emsdk_env:
-                execute(emsdk_env + " && build_clibs_wasm.bat")
-            elif shutil.which("emcc.bat"):
-                execute("build_clibs_wasm.bat")
+            if emsdk_env or shutil.which("emcc.bat"):
+                execute(emsdk_env + ["build_clibs_wasm.bat"], shell=True)
             else:
                 print(
                     "emcc not in PATH, skipping building of WASM libs. Tip: You can also use -emsdk-path to specify where emscripten lives."
                 )
 
         case Sys.linux:
-            execute("bash build_clibs_linux.sh")
+            execute(["bash", "build_clibs_linux.sh"])
 
-            build_wasm_prefix = ""
-            if emsdk_env:
-                os.environ["EMSDK_QUIET"] = "1"
-                build_wasm_prefix += emsdk_env + " && "
-                execute('bash -c "' + build_wasm_prefix + ' bash build_clibs_wasm.sh"')
-            elif shutil.which("emcc") is not None:
-                execute("bash build_clibs_wasm.sh")
+            if emsdk_env or shutil.which("emcc"):
+                execute(emsdk_env + ["bash", "build_clibs_wasm.sh"])
             else:
                 print(
                     "emcc not in PATH, skipping building of WASM libs. Tip: You can also use -emsdk-path to specify where emscripten lives."
                 )
         case Sys.osx:
-            execute("bash build_clibs_macos.sh")
-            execute("bash build_clibs_macos_dylib.sh")
+            execute(["bash", "build_clibs_macos.sh"])
+            execute(["bash", "build_clibs_macos_dylib.sh"])
 
-            build_wasm_prefix = ""
-            if emsdk_env:
-                os.environ["EMSDK_QUIET"] = "1"
-                build_wasm_prefix += emsdk_env + " && "
-                execute('bash -c "' + build_wasm_prefix + ' bash build_clibs_wasm.sh"')
-            elif shutil.which("emcc") is not None:
-                execute("bash build_clibs_wasm.sh")
+            if emsdk_env or shutil.which("emcc"):
+                execute(emsdk_env + ["bash", "build_clibs_wasm.sh"])
             else:
                 print(
                     "emcc not in PATH, skipping building of WASM libs. Tip: You can also use -emsdk-path to specify where emscripten lives."
                 )
 
-    os.chdir(owd)
+    chdir(owd)
 
 
-def get_emscripten_env_command():
+def emscripten_env():
     if args.emsdk_path is None:
-        return None
+        return []
 
-    if SYSTEM is Sys.win:
-        return os.path.join(args.emsdk_path, "emsdk_env.bat")
-    return "source " + os.path.join(args.emsdk_path, "emsdk_env.sh")
+    if SYSTEM is Sys.win32:
+        envcmd_path = Path(args.emsdk_path) / "emsdk_env.bat"
+    else:
+        environ["EMSDK_QUIET"] = "1"
+        envcmd_path = Path("source") / args.emsdk_path / "emsdk_env.sh"
+    return [str(envcmd_path.resolve()), "&&"]
 
 
 def process_exists(process_name):
-    if SYSTEM is Sys.win:
+    if SYSTEM is Sys.win32:
         call = "TASKLIST", "/NH", "/FI", "imagename eq %s" % process_name
         return process_name in str(subprocess.check_output(call))
     out = subprocess.run(
         ["pgrep", "-f", process_name], capture_output=True, text=True
     ).stdout
     return out != ""
-
-
-def make_dirs(path):
-    n = os.path.normpath(path)
-    s = n.split(os.sep)
-    p = ""
-
-    for d in s:
-        p = os.path.join(p, d)
-
-        if not os.path.exists(p):
-            os.mkdir(p)
 
 
 print = functools.partial(print, flush=True)

--- a/build.py
+++ b/build.py
@@ -75,11 +75,6 @@ if args.web:
 if num_build_modes > 1:
     print("Can only use one of: -hot-reload, -release and -web.")
     exit(1)
-elif num_build_modes == 0 and not args.update_sokol and not args.compile_sokol:
-    print(
-        "You must use one of: -hot-reload, -release, -web, -update-sokol or -compile-sokol."
-    )
-    exit(1)
 
 SYSTEM = platform.system()
 IS_WINDOWS = SYSTEM == "Windows"
@@ -113,7 +108,7 @@ def main():
         exe_path = build_release()
     elif args.web:
         exe_path = build_web()
-    elif args.hot_reload:
+    else:
         exe_path = build_hot_reload()
 
     if exe_path != "" and args.run:


### PR DESCRIPTION
Hey, thanks a lot for the cross-platform build script :)
I saw two minor issues but to fix them I also updated the formatting (Python uses 4 spaces by default).
The WASM build wasn't executed on Mac/Linux when providing a custom `-emsdk-path` and I also later noticed you mention `-hot-reload` as the default flag but the script complains when nothing is provided.
I also took the opportunity to "reduce" some boilerplate using higher-level Python stuff and I swear I cared to test it on Mac (arm64) /Linux/Windows (not all flags though), so take it if you wish ;) lol