### PR TITLE
fix missing audio in web build

### DIFF
--- a/build.py
+++ b/build.py
@@ -303,6 +303,7 @@ def build_web():
 	emcc_files = [
 		"%s/game.wasm.o" % out_dir,
 		"source/sokol/app/sokol_app_wasm_gl_" + wasm_lib_suffix,
+		"source/sokol/audio/sokol_audio_wasm_gl_" + wasm_lib_suffix,
 		"source/sokol/glue/sokol_glue_wasm_gl_" + wasm_lib_suffix,
 		"source/sokol/gfx/sokol_gfx_wasm_gl_" + wasm_lib_suffix,
 		"source/sokol/shape/sokol_shape_wasm_gl_" + wasm_lib_suffix,


### PR DESCRIPTION
This error lead to a blackscreen if you used any sokol_audio function.

An open issue is that if you pass `-sERROR_ON_UNDEFINED_SYMBOLS=1` to emscripten then you get errors about undefined symbols:
```
> python build.py -web
Building shaders...
Building js_wasm32 game object...
Building web application using emscripten to build/web...
error: undefined symbol: cos (referenced by root reference (e.g. compiled C/C++ code))
warning: To disable errors for undefined symbols use `-sERROR_ON_UNDEFINED_SYMBOLS=0`
warning: _cos may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library
error: undefined symbol: sin (referenced by root reference (e.g. compiled C/C++ code))
warning: _sin may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library
error: undefined symbol: time_now (referenced by root reference (e.g. compiled C/C++ code))
warning: _time_now may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library
error: undefined symbol: write (referenced by root reference (e.g. compiled C/C++ code))
warning: _write may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library
Error: Aborting compilation due to previous errors
```
I'm not sure if this is worth investigating.