### PR TITLE
Fix build.py hot reload errors on windows

### DIFF
--- a/build.py
+++ b/build.py
@@ -221,10 +221,9 @@ def build_hot_reload():
 		gfxapi = "gl" if args.gl else "d3d11"
 		release_type = "debug" if args.debug else "release"
 		dll_name = "sokol_dll_windows_x64_%s_%s.dll" % (gfxapi, release_type)
-
-		if not os.path.exists(dll_name):
-			print("Copying %s" % dll_name)
-			shutil.copyfile(SOKOL_PATH + "/" + dll_name, dll_name)
+		src = SOKOL_PATH + "/" + dll_name
+		dest = dll_name
+		copy_file_if_different(src, dest)
 
 	if IS_OSX:
 		dylib_folder = "source/sokol/dylib"
@@ -241,16 +240,7 @@ def build_hot_reload():
 		for d in dylibs:
 			src = "%s/%s" % (dylib_folder, d)
 			dest = "dylib/%s" % d
-			do_copy = False
-
-			if not os.path.exists(dest):
-				do_copy = True
-			elif os.path.getsize(dest) != os.path.getsize(src):
-				do_copy = True
-
-			if do_copy:
-				print("Copying %s to %s" % (src, dest))
-				shutil.copyfile(src, dest)
+			copy_file_if_different(src, dest)
 
 	return "./" + exe
 
@@ -498,6 +488,18 @@ def make_dirs(path):
 
 		if not os.path.exists(p):
 			os.mkdir(p)
+
+def copy_file_if_different(src, dest):
+	do_copy = False
+	if not os.path.exists(dest):
+		do_copy = True
+	elif os.path.getsize(dest) != os.path.getsize(src) or os.path.getmtime(dest) != os.path.getmtime(src):
+		do_copy = True
+
+	if do_copy:
+		print("Copying %s to %s" % (src, dest))
+		shutil.copyfile(src, dest)
+	return
 
 print = functools.partial(print, flush=True)
 


### PR DESCRIPTION
Fixes two errors on Windows as per the commit messages:
 - OpenGL hot reload didn't work at all because of missing DLL copies
 - out of date DLLs in hot reload builds weren't updated with newer ones (on OSX this issue was already fixed)