### PR TITLE
fix Windows OpenGL shader compilation

### DIFF
--- a/build.py
+++ b/build.py
@@ -103,7 +103,7 @@ def build_shaders():
 		if args.web:
 			langs = "glsl300es"
 		elif IS_WINDOWS:
-			langs = "hlsl5"
+			langs = "glsl430" if args.gl else "hlsl5"
 		elif IS_LINUX:
 			langs = "glsl430"
 		elif IS_OSX:


### PR DESCRIPTION
The -gl flag wasn't checked for Windows shader compilation.
I think this is the last one for a while :)

Sorry for the many small changes and thanks for looking at them so quickly!
Also, thanks for the template, it's very nice to work with! 👍 